### PR TITLE
Add overwrite prompt with rename option for existing files - Issue #3

### DIFF
--- a/age-store.py
+++ b/age-store.py
@@ -222,6 +222,24 @@ def cmd_add_file(file_path_str: str):
     encrypted_content = encrypt_with_age_recipients(content, [master_public_key])
     secret_file = STORE_DIR / f"{file_path.name}.enc"
 
+    # Check if encrypted file already exists
+    while secret_file.exists():
+        response = input(f"File {secret_file} already exists in store. Overwrite, rename, or skip? [y/N/r]: ").strip().lower()
+        if response == 'y':
+            break  # Proceed to overwrite
+        elif response == 'r':
+            new_name = input(f"Enter new filename (without .enc): ").strip()
+            if not new_name:
+                print("Error: No filename provided, skipping")
+                return
+            secret_file = STORE_DIR / f"{new_name}.enc"
+            if secret_file.exists():
+                print(f"Error: File {secret_file} already exists, try again")
+                continue
+        else:  # Default to 'n' or any other input
+            print(f"Skipping {file_path}: not overwritten")
+            return
+
     with open(secret_file, "wb") as f:
         f.write(encrypted_content)
 


### PR DESCRIPTION
Modified `cmd_add_file` to prompt users when a file exists in the store. Options:
- `y`: Overwrite the file.
- `n` (default): Skip without overwriting.
- `r`: Rename to a new filename, with checks for existing files.
Closes #3.